### PR TITLE
15.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # CHANGELOG
 
+## Version Update
+- Require `Myotus` version to 15.0.7
+
+## Features
+- Extended Wireless Terminal support `Quantum Bridge Card`
+
 ## Bug Fixes
-- fix crash when open extended crafting guideme page  
+- fix JEI missingSlot miss match in shapeless crafting recipe
+- Fixed AE2WTLib Wireless Universal Terminal recipes to preserve Myotus upgrade storage data

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+1. et wireless terminal quantum link 구현하기
+2. Myotus업그레이드인 ITerminalUpgradeCard를 터미널에 SideUpgradePanel에 장착한 상태로 다른 wireless terminal이랑 합쳐서 universal terminal로 만들면 SideUpgradePanel에 아무것도 안남앙있음 
+3. jei의 missingSlot 잘 못 표기 되고 있음. ae2wtlib에 wct를 잘 찾아보고 또는 CraftingTermMenu를 잘 찾아보고 뭐가 다른지 고쳐줘

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ mod_id=extendedterminal
 mod_name=Extended Terminal
 mod_license=GNU LGPL 3.0
 mod_loader=forge
-mod_version=15.0.2
+mod_version=15.0.3
 mod_group_id=me.myogoo
 java_version=17
 mod_version_type=beta
@@ -19,8 +19,8 @@ mod_version_type=beta
 mod_authors=NJoyShadow
 mod_description=Add some terminal like extended crafting
 
-Myotus_version=15.0.3
-myotus_version_range=[15.0.3,)
+Myotus_version=15.0.7
+myotus_version_range=[15.0.7,)
 AE2_version=15.4.10
 AE2WTLib_version=15.3.3-forge
 
@@ -37,7 +37,7 @@ Cucumber_version=7.0.14
 ExtendedCrafting_version=6.0.9
 guideME_version=20.1.11
 
-itemListMod=emi
+itemListMod=jei
 
 enable_avaritia=re
 enable_excrafting=ex

--- a/src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java
+++ b/src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java
@@ -10,7 +10,6 @@ import me.myogoo.myotus.api.MyotusAPI;
 import me.myogoo.myotus.api.annotation.wt.AE2WTLib;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -36,7 +35,7 @@ public class ExtendedTerminal {
         if (MyotusAPI.get().modIntegrationManager().isLoaded(AE2WTLib.class)) {
             WTItems.register();
             WTMenus.register();
-            modEventBus.addListener(EventPriority.LOWEST,WTInits::init);
+            WTInits.registerTerminal();
         }
 
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/me/myogoo/extendedterminal/init/wt/WTInits.java
+++ b/src/main/java/me/myogoo/extendedterminal/init/wt/WTInits.java
@@ -1,23 +1,24 @@
 package me.myogoo.extendedterminal.init.wt;
 
-import appeng.api.features.GridLinkables;
-import appeng.items.tools.powered.WirelessTerminalItem;
-import de.mari_023.ae2wtlib.wut.WUTHandler;
 import me.myogoo.extendedterminal.me.host.ETWTHost;
+import me.myogoo.extendedterminal.menu.ETMenuType;
 import me.myogoo.extendedterminal.menu.extendedterminal.wt.ETWTMenu;
-import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegisterEvent;
+import me.myogoo.myotus.api.wt.AddTerminalEvent;
 
-public class WTInits {
-    public static void init(RegisterEvent event) {
-        if (event.getRegistryKey().equals(ForgeRegistries.Keys.ITEMS)) {
-            WUTHandler
-                    .addTerminal("wireless_et_terminal",
-                            WTItems.WIRELESS_ET_TERMINAL.asItem()::tryOpen,
-                            ETWTHost::new,
-                            ETWTMenu.TYPE,
-                            WTItems.WIRELESS_ET_TERMINAL.asItem());
-        }
+public final class WTInits {
+    private WTInits() {
+    }
+
+    public static synchronized void registerTerminal() {
+        AddTerminalEvent.register(event -> {
+            var terminalName = ETMenuType.ET_TERMINAL.getWTIdAsString();
+            event.addTerminal(
+                    terminalName,
+                    ETWTHost::new,
+                    ETWTMenu.TYPE,
+                    WTItems.WIRELESS_ET_TERMINAL.asItem(),
+                    terminalName,
+                    "item.extendedterminal.wireless_et_terminal");
+        });
     }
 }

--- a/src/main/java/me/myogoo/extendedterminal/init/wt/WTItems.java
+++ b/src/main/java/me/myogoo/extendedterminal/init/wt/WTItems.java
@@ -7,8 +7,6 @@ import de.mari_023.ae2wtlib.terminal.ItemWT;
 import me.myogoo.extendedterminal.ExtendedTerminal;
 import me.myogoo.extendedterminal.init.ETItems;
 import me.myogoo.extendedterminal.item.wtitem.ETWTItem;
-import me.myogoo.myotus.api.annotation.wt.AE2WTLib;
-import me.myogoo.myotus.util.mod.ModIntegrationManager;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 

--- a/src/main/java/me/myogoo/extendedterminal/integration/jei/extendedterminal/handler/ETCraftingRecipeTransfer.java
+++ b/src/main/java/me/myogoo/extendedterminal/integration/jei/extendedterminal/handler/ETCraftingRecipeTransfer.java
@@ -63,7 +63,7 @@ public class ETCraftingRecipeTransfer<T extends ETTerminalMenu>
 
         boolean craftMissing = AbstractContainerScreen.hasControlDown();
         List<IRecipeSlotView> inputSlots = recipeSlots.getSlotViews(RecipeIngredientRole.INPUT);
-        var slotToIngredientMap = ETCraftingRecipeTransferHelper.getGuiSlotToIngredientMap(menu, recipe);
+        var slotToIngredientMap = ETCraftingRecipeTransferHelper.getJeiDisplaySlotToIngredientMap(recipe);
         var missingSlots = menu.findMissingIngredients(slotToIngredientMap);
         if (!slotToIngredientMap.isEmpty() && missingSlots.missingSlots().size() == slotToIngredientMap.size()) {
             var missingSlotViews = missingSlots.missingSlots().stream()

--- a/src/main/java/me/myogoo/extendedterminal/integration/module/extendedterminal/ETCraftingRecipeTransferHelper.java
+++ b/src/main/java/me/myogoo/extendedterminal/integration/module/extendedterminal/ETCraftingRecipeTransferHelper.java
@@ -7,15 +7,13 @@ import appeng.integration.modules.jeirei.EncodingHelper;
 import appeng.menu.me.common.GridInventoryEntry;
 import me.myogoo.extendedterminal.menu.extendedterminal.ETTerminalMenu;
 import net.minecraft.core.NonNullList;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.ShapedRecipe;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public final class ETCraftingRecipeTransferHelper {
@@ -30,7 +28,7 @@ public final class ETCraftingRecipeTransferHelper {
         int gridWidth = menu.getCraftingGridWidth();
         int recipeWidth = recipe instanceof ShapedRecipe shapedRecipe ? shapedRecipe.getWidth() : gridWidth;
 
-        var result = new HashMap<Integer, Ingredient>(ingredients.size());
+        var result = new LinkedHashMap<Integer, Ingredient>(ingredients.size());
         for (int i = 0; i < ingredients.size(); i++) {
             int guiSlot = (i / recipeWidth) * gridWidth + (i % recipeWidth);
             var ingredient = ingredients.get(i);
@@ -39,6 +37,62 @@ public final class ETCraftingRecipeTransferHelper {
             }
         }
         return result;
+    }
+
+    public static Map<Integer, Ingredient> getJeiDisplaySlotToIngredientMap(CraftingRecipe recipe) {
+        var ingredients = recipe.getIngredients();
+
+        int width, height;
+        if (recipe instanceof ShapedRecipe shapedRecipe) {
+            width = shapedRecipe.getWidth();
+            height = shapedRecipe.getHeight();
+        } else {
+            if (ingredients.size() > 4) {
+                width = height = 3;
+            } else if (ingredients.size() > 1) {
+                width = height = 2;
+            } else {
+                width = height = 1;
+            }
+        }
+
+        var result = new LinkedHashMap<Integer, Ingredient>(ingredients.size());
+        for (int i = 0; i < ingredients.size(); i++) {
+            int guiSlot = getCraftingIndex(i, width, height);
+            var ingredient = ingredients.get(i);
+            if (!ingredient.isEmpty()) {
+                result.put(guiSlot, ingredient);
+            }
+        }
+        return result;
+    }
+
+    private static int getCraftingIndex(int i, int width, int height) {
+        int index;
+        if (width == 1) {
+            if (height == 3) {
+                index = (i * 3) + 1;
+            } else if (height == 2) {
+                index = (i * 3) + 1;
+            } else {
+                index = 4;
+            }
+        } else if (height == 1) {
+            index = i + 3;
+        } else if (width == 2) {
+            index = i;
+            if (i > 1) {
+                index++;
+                if (i > 3) {
+                    index++;
+                }
+            }
+        } else if (height == 2) {
+            index = i + 3;
+        } else {
+            index = i;
+        }
+        return index;
     }
 
     public static void performTransfer(ETTerminalMenu menu, CraftingRecipe recipe,

--- a/src/main/java/me/myogoo/extendedterminal/menu/extendedterminal/ETTerminalMenu.java
+++ b/src/main/java/me/myogoo/extendedterminal/menu/extendedterminal/ETTerminalMenu.java
@@ -24,6 +24,7 @@ import me.myogoo.extendedterminal.menu.extendedterminal.slot.ETStoneCutterSlot;
 import me.myogoo.extendedterminal.menu.slot.ETCraftingBaseSlot;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.DataSlot;
@@ -251,6 +252,27 @@ public class ETTerminalMenu extends ETTerminalBaseMenu<CraftingRecipe> {
             return;
         }
         super.doAction(player, action, slot, id);
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int idx) {
+        if (isServerSide() && idx >= 0 && idx < this.slots.size() && this.getSlot(idx) == this.anvilOutputSlot) {
+            ItemStack before = this.anvilOutputSlot.getItem().copy();
+            if (!before.isEmpty() && this.anvilOutputSlot.mayPickup(player)) {
+                int beforeCount = before.getCount();
+                super.quickMoveStack(player, idx);
+
+                ItemStack after = this.anvilOutputSlot.getItem();
+                int afterCount = after.isEmpty() ? 0 : after.getCount();
+                if (afterCount < beforeCount) {
+                    ItemStack taken = before.copy();
+                    taken.setCount(beforeCount - afterCount);
+                    this.anvilOutputSlot.onTake(player, taken);
+                }
+                return ItemStack.EMPTY;
+            }
+        }
+        return super.quickMoveStack(player, idx);
     }
 
     private void updateCraftingOutput(boolean forceUpdate) {

--- a/src/main/resources/assets/extendedterminal/lang/en_us.json
+++ b/src/main/resources/assets/extendedterminal/lang/en_us.json
@@ -3,7 +3,7 @@
 
   "item.extendedterminal.et_terminal": "Extended Terminal",
   "item.extendedterminal.wireless_et_terminal": "Wireless Extended Terminal",
-  "key.ae2.wireless_wireless_et_terminal_terminal": "Wireless Extended Terminal",
+  "key.ae2.wireless_et_terminal": "Open Wireless Extended Terminal",
 
   "item.extendedterminal.basic_terminal": "Basic Extended Crafting Terminal",
   "item.extendedterminal.advanced_terminal": "Advanced Extended Crafting Terminal",


### PR DESCRIPTION
This pull request introduces several feature enhancements, bug fixes, and internal improvements to the Extended Terminal mod. The main highlights are the extension of Wireless Terminal support to include the Quantum Bridge Card, updates to ensure compatibility with Myotus version 15.0.7, and significant fixes for crafting and integration with JEI (Just Enough Items). Additionally, there are code refactors to improve how wireless terminals are registered and how crafting recipe slots are mapped, especially for shapeless recipes.

**Feature Enhancements:**

* Added support for the Quantum Bridge Card in Wireless Terminals, expanding the range of compatible features.
* Updated mod to require Myotus version 15.0.7 for improved compatibility and stability. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L14-R23) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11)

**Bug Fixes and Crafting Improvements:**

* Fixed an issue where JEI would incorrectly display missing slots in shapeless crafting recipes, improving user experience with recipe transfers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-3484a31b67824bb455d3ed3f9e473a4a978793f7747fb81fc7a23dc7289088c9R42-R97) [[3]](diffhunk://#diff-c00c34fa888960b84dfb6494ea3398354a70ec4f9a3c73757af79e49a878d7efL66-R66)
* Ensured that AE2WTLib Wireless Universal Terminal recipes now properly preserve Myotus upgrade storage data, preventing data loss during crafting.
* Improved quick-move stack behavior in the `ETTerminalMenu`, especially for anvil output slots, ensuring correct item handling on shift-click.

**Internal Refactoring and Integration:**

* Refactored wireless terminal registration to use the `AddTerminalEvent` system, streamlining integration with Myotus and AE2WTLib. [[1]](diffhunk://#diff-b656332cf3e25ed0eb0b5284819b75b3cfe9f56ffb800bd406a55db2c338f254L3-R22) [[2]](diffhunk://#diff-8dea274c4ce72fdf4d3f44c3f573207fa1d44be6595009d6ef7d18a41eddae2cL39-R38)
* Improved crafting recipe slot mapping to use `LinkedHashMap` for deterministic ordering and added a dedicated method for JEI display slot mapping, addressing previous slot mismatch issues. [[1]](diffhunk://#diff-3484a31b67824bb455d3ed3f9e473a4a978793f7747fb81fc7a23dc7289088c9L33-R31) [[2]](diffhunk://#diff-3484a31b67824bb455d3ed3f9e473a4a978793f7747fb81fc7a23dc7289088c9R42-R97)

**Localization and Configuration:**

* Updated English localization for wireless terminal key bindings to improve clarity.
* Changed default item list mod from EMI to JEI in configuration for better compatibility.

These changes collectively improve mod stability, user experience with crafting and wireless terminals, and maintain compatibility with the latest dependencies.