### PR TITLE
19.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           loaders: ${{ needs.build.outputs.mod_loader }}
           version-type: ${{ needs.build.outputs.version_type }}
 
-          files: 'build/libs/*.jar'
+          files: ${{ needs.build.outputs.artifact_path }}
           name: ${{ needs.build.outputs.artifact_name }}
           version: ${{ needs.build.outputs.mc_version }}-${{ needs.build.outputs.mod_version }}
 
@@ -111,7 +111,7 @@ jobs:
           loaders: ${{ needs.build.outputs.mod_loader }}
           version-type: ${{ needs.build.outputs.version_type }}
 
-          files: 'build/libs/*.jar'
+          files: ${{ needs.build.outputs.artifact_path }}
           name: ${{ needs.build.outputs.artifact_name }}
           version: ${{ needs.build.outputs.mc_version }}-${{ needs.build.outputs.mod_version }}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,12 +17,12 @@ mod_version_type=release
 mod_id=extendedterminal
 mod_name=Extended Terminal
 mod_license=LGPL-3.0
-mod_version=19.0.2
+mod_version=19.0.3
 mod_group_id=me.myogoo
 mod_authors=myogoo
 mod_description=Add some terminal like extended crafting
 
-myotus_version=19.0.5
+myotus_version=19.0.9
 AE2_version=19.2.17
 AE2WTLib_version=19.2.5
 JEI_version=19.19.3.224

--- a/src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java
+++ b/src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java
@@ -8,6 +8,7 @@ import me.myogoo.extendedterminal.init.wt.WTMenus;
 import me.myogoo.myotus.api.MyotusAPI;
 import me.myogoo.myotus.api.annotation.wt.AE2WTLib;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
@@ -33,7 +34,8 @@ public class ExtendedTerminal {
         if(MyotusAPI.modIntegrationManager().isLoaded(AE2WTLib.class)) {
             WTItems.register();
             WTMenus.register();
-            modEventBus.addListener(WTInit::init);
+            WTInit.registerTerminal();
+            modEventBus.addListener(EventPriority.LOWEST, WTInit::registerUpgradeTooltips);
             modEventBus.addListener(WTInit::initCapabilities);
         }
 

--- a/src/main/java/me/myogoo/extendedterminal/init/wt/WTInit.java
+++ b/src/main/java/me/myogoo/extendedterminal/init/wt/WTInit.java
@@ -1,23 +1,24 @@
 package me.myogoo.extendedterminal.init.wt;
 
 import appeng.api.features.GridLinkables;
+import appeng.api.upgrades.Upgrades;
 import appeng.items.tools.powered.WirelessTerminalItem;
 import appeng.items.tools.powered.powersink.PoweredItemCapabilities;
+import de.mari_023.ae2wtlib.api.AE2wtlibAPI;
 import de.mari_023.ae2wtlib.api.gui.Icon;
 import de.mari_023.ae2wtlib.api.registration.AddTerminalEvent;
 import de.mari_023.ae2wtlib.api.registration.WTDefinition;
 import de.mari_023.ae2wtlib.api.terminal.ItemWT;
 import me.myogoo.extendedterminal.ExtendedTerminal;
-import me.myogoo.extendedterminal.init.ETItems;
 import me.myogoo.extendedterminal.me.host.ETWTHost;
 import me.myogoo.extendedterminal.menu.ETMenuType;
 import me.myogoo.extendedterminal.menu.extendedterminal.wt.ETWTMenu;
 import me.myogoo.myotus.api.annotation.wt.AE2WTLib;
 import me.myogoo.myotus.api.MyotusAPI;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
@@ -28,13 +29,15 @@ import static me.myogoo.extendedterminal.init.wt.WTItems.WT_ITEMS;
 public class WTInit {
     private final static ResourceLocation ICON_SRC = ExtendedTerminal.makeId("textures/guis/icons.png");
     private final static Icon.Texture TEXTURE = new Icon.Texture(ICON_SRC, 128, 128);
+    private static boolean terminalRegistered = false;
 
-    public static void init(RegisterEvent event) {
-        if (event.getRegistryKey().equals(Registries.ITEM)
-                && MyotusAPI.get().modIntegrationManager().isLoaded(AE2WTLib.class)) {
-            register(WTItems.WIRELESS_ET_TERMINAL, ETMenuType.ET_TERMINAL, ETWTHost::new, ETWTMenu.TYPE,
-                    new Icon(0, 0, 16, 16, TEXTURE));
+    public static synchronized void registerTerminal() {
+        if (terminalRegistered || !MyotusAPI.get().modIntegrationManager().isLoaded(AE2WTLib.class)) {
+            return;
         }
+        terminalRegistered = true;
+        register(WTItems.WIRELESS_ET_TERMINAL, ETMenuType.ET_TERMINAL, ETWTHost::new, ETWTMenu.TYPE,
+                new Icon(0, 0, 16, 16, TEXTURE));
     }
 
     private static void register(ItemLike terminal, ETMenuType etMenuType, WTDefinition.WTMenuHostFactory host,
@@ -42,8 +45,16 @@ public class WTInit {
         AddTerminalEvent
                 .register(e -> e.builder(etMenuType.getWTIdAsString(), host, menuType, (ItemWT) terminal.asItem(), icon)
                         .addTerminal());
+    }
 
-        GridLinkables.register(terminal, WirelessTerminalItem.LINKABLE_HANDLER);
+    public static void registerUpgradeTooltips(RegisterEvent event) {
+        if (!event.getRegistryKey().equals(Registries.ITEM)) {
+            return;
+        }
+
+        BuiltInRegistries.ITEM.getOptional(AE2wtlibAPI.id("quantum_bridge_card"))
+                .ifPresent(card -> Upgrades.add(card, WTItems.WIRELESS_ET_TERMINAL.asItem(), 1));
+        GridLinkables.register(WTItems.WIRELESS_ET_TERMINAL.asItem(), WirelessTerminalItem.LINKABLE_HANDLER);
     }
 
     public static void initCapabilities(RegisterCapabilitiesEvent event) {

--- a/src/main/java/me/myogoo/extendedterminal/init/wt/WTItems.java
+++ b/src/main/java/me/myogoo/extendedterminal/init/wt/WTItems.java
@@ -28,9 +28,6 @@ public class WTItems {
 
     private static <T extends Item> ItemDefinition<T> createWTItem(String name, ResourceLocation id,
                                                                    Function<Item.Properties, T> itemFactory) {
-        if (!MyotusAPI.get().modIntegrationManager().isLoaded(AE2WTLib.class)) {
-            return null;
-        }
         var item = ETItems.REGISTER.registerItem(id.getPath(), itemFactory);
         var definition = new ItemDefinition<>(name, item);
         WT_ITEMS.add(definition);

--- a/src/main/java/me/myogoo/extendedterminal/menu/extendedterminal/ETTerminalMenu.java
+++ b/src/main/java/me/myogoo/extendedterminal/menu/extendedterminal/ETTerminalMenu.java
@@ -25,6 +25,7 @@ import me.myogoo.extendedterminal.menu.slot.ETCraftingBaseSlot;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -213,6 +214,27 @@ public class ETTerminalMenu extends ETTerminalBaseMenu<CraftingRecipe> {
             return;
         }
         super.doAction(player, action, slot, id);
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int idx) {
+        if (isServerSide() && idx >= 0 && idx < this.slots.size() && this.getSlot(idx) == this.anvilOutputSlot) {
+            ItemStack before = this.anvilOutputSlot.getItem().copy();
+            if (!before.isEmpty() && this.anvilOutputSlot.mayPickup(player)) {
+                int beforeCount = before.getCount();
+                super.quickMoveStack(player, idx);
+
+                ItemStack after = this.anvilOutputSlot.getItem();
+                int afterCount = after.isEmpty() ? 0 : after.getCount();
+                if (afterCount < beforeCount) {
+                    ItemStack taken = before.copy();
+                    taken.setCount(beforeCount - afterCount);
+                    this.anvilOutputSlot.onTake(player, taken);
+                }
+                return ItemStack.EMPTY;
+            }
+        }
+        return super.quickMoveStack(player, idx);
     }
 
     // ---------------------------------------------------------------------

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -31,7 +31,7 @@ modId = "myotus"
 type = "REQUIRED"
 ordering="AFTER"
 side="BOTH"
-versionRange = "[19.0.5,)"
+versionRange = "[19.0.9,)"
 
 [[dependencies."${mod_id}"]]
 modId = "ae2wtlib"


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to integration with AE2WTLib, item upgrade handling, and internal workflow consistency. The most significant changes include refactoring the wireless terminal registration process, ensuring proper upgrade support, and synchronizing version numbers across dependencies.

**AE2WTLib Integration and Wireless Terminal Registration:**

* Refactored the wireless terminal registration logic by introducing a synchronized `registerTerminal()` method in `WTInit.java` to ensure the terminal is registered only once and only when AE2WTLib is present. The previous registration logic in the event listener was removed. (`src/main/java/me/myogoo/extendedterminal/init/wt/WTInit.java`, `src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java`) [[1]](diffhunk://#diff-2ecbea3798385e91f056bc38d99ed52c0409506f3f9a4a463a195c5dabdf89c3R32-R57) [[2]](diffhunk://#diff-8dea274c4ce72fdf4d3f44c3f573207fa1d44be6595009d6ef7d18a41eddae2cL36-R38)
* Added a new `registerUpgradeTooltips()` method in `WTInit.java` to support adding the quantum bridge card as an upgrade to the wireless terminal and registering it with `GridLinkables`. This is now registered with lowest event priority. (`src/main/java/me/myogoo/extendedterminal/init/wt/WTInit.java`, `src/main/java/me/myogoo/extendedterminal/ExtendedTerminal.java`) [[1]](diffhunk://#diff-2ecbea3798385e91f056bc38d99ed52c0409506f3f9a4a463a195c5dabdf89c3R32-R57) [[2]](diffhunk://#diff-8dea274c4ce72fdf4d3f44c3f573207fa1d44be6595009d6ef7d18a41eddae2cL36-R38)

**Dependency and Version Synchronization:**

* Updated `mod_version` to `19.0.3` and `myotus_version` to `19.0.9` in `gradle.properties`, and synchronized the required dependency version for Myotus in `neoforge.mods.toml` to `[19.0.9,)`. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L20-R25) [[2]](diffhunk://#diff-6b3f418565af1cc3b07b98c5fba98212b75949f6f085c24bf180d9aa5f888f88L34-R34)

**Workflow Consistency:**

* Changed the artifact path in the GitHub Actions `publish.yml` workflow to use the dynamically generated output path from the build step instead of a hardcoded glob pattern. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L82-R82) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L114-R114)

**Wireless Terminal Item Creation:**

* Removed the redundant AE2WTLib presence check from the `createWTItem` method in `WTItems.java`, relying instead on the improved registration logic.

**Menu and UI Handling:**

* Overrode `quickMoveStack` in `ETTerminalMenu.java` to properly handle the anvil output slot, ensuring correct item transfer and callback invocation when shift-clicking results.

These changes improve the reliability of AE2WTLib integration, ensure proper upgrade support, and streamline build and deployment processes.