### PR TITLE
19.0.3/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## Bug fixes
-- Fix: Unable to load AvaritiaNeo terminal.
+## Features
+- Register the Wireless Extended Terminal as compatible with AE2WTLib's Quantum Bridge Card upgrade.
 
 ## Dependency updates
-- update required Myotus version to 19.0.5
+- Update required Myotus version to 19.0.9.


### PR DESCRIPTION
This pull request updates the project with a new feature and a dependency version bump. The most notable change is the addition of compatibility for the Wireless Extended Terminal with AE2WTLib's Quantum Bridge Card upgrade.

Feature addition:

* Registered the Wireless Extended Terminal as compatible with AE2WTLib's Quantum Bridge Card upgrade.

Dependency update:

* Updated the required Myotus version from 19.0.5 to 19.0.9.